### PR TITLE
Release 0.2.0 -- change default SSL policy

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "internal" {
 
 variable "ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-2016-08"
+  default = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 }
 
 variable "tg_name" {


### PR DESCRIPTION
### Changed (breaking)
- Changed the default SSL policy. The new default supports TLS 1.3 and 1.2, but disables TLS 1.1 and 1.0. [Documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies)
