### PR TITLE
Release 1.1.0 -- add support for dualstack-without-ipv4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_alb" "alb" {
   subnets            = var.subnets
   load_balancer_type = var.load_balancer_type
   idle_timeout       = var.idle_timeout
-  ip_address_type    = var.enable_ipv6 ? "dualstack" : "ipv4"
+  ip_address_type    = var.enable_ipv6 ? (var.disable_public_ipv4 ? "dualstack" : "dualstack-without-public-ipv4") : "ipv4"
 
   tags = {
     Name     = coalesce(var.alb_name, "alb-${var.app_name}-${var.app_env}")

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,13 @@ variable "load_balancer_type" {
 }
 
 variable "enable_ipv6" {
-  description = "Set to `true` to enable IPv6. Changes the ALB `ip_address_type` to `\"dualstack\"`."
+  description = "Set to `true` to enable IPv6"
+  type        = bool
+  default     = false
+}
+
+variable "disable_public_ipv4" {
+  description = "false: use public IPv4; true: if enable_ipv6 is true, ip_address_type will be \"dualstack-without-public-ipv4\", otherwise, \"dualstack\""
   type        = bool
   default     = false
 }


### PR DESCRIPTION
### Added
- Added new input `disable_public_ipv4` to remove the IPv4 addresses from the load balancer

