### PR TITLE
add support for aws provider v6

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = ">= 4.0.0, < 7.0.0"
     }
   }
 }


### PR DESCRIPTION
[ITSE-2706](https://support.gtis.sil.org/issue/ITSE-2706) Update Terraform AWS provider to 6.x

---

### Added
- support for AWS provider v6